### PR TITLE
fixed issue with regex characters crashing the bot using the seen command

### DIFF
--- a/drawbot.js
+++ b/drawbot.js
@@ -491,7 +491,7 @@ function PerformLastSeen(channel, text) {
 		var rd = readline.createInterface(fs.createReadStream('./skd.log'), stream);
 		
 		rd.on('line', function(line) {
-			var reg = new RegExp('plain-logs - <'+who+'>', 'i');
+			var reg = new RegExp('plain-logs - <'+who.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")+'>', 'i');
 			if( reg.test(line) )
 				temp = line;
 		});


### PR DESCRIPTION
It just escapes regex characters now when building the regex string.
